### PR TITLE
Make FSDP the default sharding strategy

### DIFF
--- a/examples/singlehost/sft_lora_example.py
+++ b/examples/singlehost/sft_lora_example.py
@@ -42,7 +42,7 @@ from kithara import (
     PredefinedShardingStrategy,
     SFTDataset,
 )
-import jax 
+import jax
 
 config = {
     "model": "gemma",
@@ -73,9 +73,6 @@ def run_workload(
         f"hf://{config['model_handle']}",
         precision=config["precision"],
         lora_rank=config["lora_rank"] if config["use_lora"] else None,
-        sharding_strategy=PredefinedShardingStrategy(
-            parallelism="fsdp", model=config["model"]
-        ),
     )
     # Create tokenizer
     tokenizer = AutoTokenizer.from_pretrained(config["model_handle"])
@@ -129,12 +126,15 @@ def run_workload(
 
 if __name__ == "__main__":
 
-    dataset_items = [{
-        "prompt": "What is your name?",
-        "answer": "My name is Mary",
-    }  for _ in range(1000)]
+    dataset_items = [
+        {
+            "prompt": "What is your name?",
+            "answer": "My name is Mary",
+        }
+        for _ in range(1000)
+    ]
     dataset = ray.data.from_items(dataset_items)
-    train_ds, eval_ds= dataset.train_test_split(test_size=500)
+    train_ds, eval_ds = dataset.train_test_split(test_size=500)
 
     run_workload(
         train_ds,

--- a/kithara/dataset/text_completion.py
+++ b/kithara/dataset/text_completion.py
@@ -112,8 +112,9 @@ class TextCompletionDataset(Dataset):
         # Avoid circular import
         from kithara.model import ModelImplementationType
 
-        model_type = self.model_type or global_state.get_global_attribute(
-            "MODEL_IMPLEMENTATION"
+        # global attribute takes precedence 
+        model_type = global_state.get_global_attribute(
+            "MODEL_IMPLEMENTATION", self.model_type
         )
 
         if not model_type:

--- a/kithara/distributed/sharding/_layout.py
+++ b/kithara/distributed/sharding/_layout.py
@@ -22,12 +22,22 @@ from typing import ClassVar
 # Layout configurations for different model architectures
 @dataclass
 class Layout:
-    # Class-level dictionary to store mesh types
-    _mesh_types: ClassVar[dict] = {
-        "gemma": lambda: Layout.gemma(),
-    }
+    
+    _mesh_types: ClassVar[dict] = {}
+    
+    @classmethod
+    def initialize_mesh_types(cls):
+        # Avoid circular import
+        from kithara.model import supported_models
+        cls._mesh_types = {
+            supported_models.GEMMA2_2B: lambda: Layout.gemma(),
+            supported_models.GEMMA2_9B: lambda: Layout.gemma(),
+            supported_models.GEMMA2_27B: lambda: Layout.gemma(),
+        }
 
     def __class_getitem__(cls, key: str):
+        if not cls._mesh_types:
+            cls.initialize_mesh_types()
         if key not in cls._mesh_types:
             raise KeyError(f"Unknown mesh type: {key}")
         return cls._mesh_types[key]()

--- a/kithara/distributed/sharding/strategy.py
+++ b/kithara/distributed/sharding/strategy.py
@@ -96,7 +96,7 @@ class PredefinedShardingStrategy(ShardingStrategy):
         ```python
         strategy = PredefinedShardingStrategy(
             parallelism="fsdp",
-            model="gemma"
+            model="gemma2-27b"
         )
         set_global_sharding_strategy(strategy)
         ```

--- a/kithara/model/README.md
+++ b/kithara/model/README.md
@@ -29,11 +29,7 @@ First, create a KerasHub model instance to examine its structure:
 
 ```python
 model = KerasHubModel.from_preset(
-    your_model_handle,
-    sharding_strategy=PredefinedShardingStrategy(
-        parallelism="fsdp", 
-        model=config["model"]
-    ),
+    your_model_handle
 )
 
 # Examine model weights and shapes

--- a/kithara/model/kerashub/ckpt_compatibility/param_mapping.py
+++ b/kithara/model/kerashub/ckpt_compatibility/param_mapping.py
@@ -32,10 +32,7 @@ def GEMMA2_KERASHUB_TO_HF_PARAM_MAPPING(config):
     How to obtain this mapping for a new model: 
         ```
         model = KerasHubModel.from_preset(
-            "hf://google/gemma-2-2b",
-            sharding_strategy=PredefinedShardingStrategy(
-                parallelism="fsdp", model=config["model"]
-            ),
+            "hf://google/gemma-2-2b"
         )
 
         # print out all keras model weights 

--- a/kithara/model/kerashub/keras_hub_model.py
+++ b/kithara/model/kerashub/keras_hub_model.py
@@ -41,14 +41,13 @@ class KerasHubModel(Model):
         preset_handle (str): Model identifier, e.g., "hf://google/gemma-2-2b".
         lora_rank (Optional[int]): Rank for LoRA adaptation (disabled if None), applied to q_proj and v_proj
         sharding_strategy(kithara.ShardingStrategy): Strategy used for distributing model, optimizer,
-            and data tensors. E.g. `kithara.PredefinedShardingStrategy("fsdp", "gemma")`.
-            Default is "mixed_bfloat16". Supported policies include "float32", "float16", "bfloat16",
+            and data tensors. E.g. `kithara.PredefinedShardingStrategy("fsdp", "gemma2-2b")`.
+        precision (str): Default is "mixed_bfloat16". Supported policies include "float32", "float16", "bfloat16",
             "mixed_float16", and "mixed_bfloat16". Mixed precision policies load model weight in float32
             and casts activations to the specified dtype.
 
     Example Usage:
-        model = KerasHubModel.from_preset("hf://google/gemma-2-2b", lora_rank=4,
-                sharding_strategy=kithara.PredefinedShardingStrategy("fsdp", "gemma"))
+        model = KerasHubModel.from_preset("hf://google/gemma-2-2b", lora_rank=4)
     """
 
     @classmethod

--- a/kithara/model/kerashub/keras_hub_model.py
+++ b/kithara/model/kerashub/keras_hub_model.py
@@ -18,7 +18,7 @@ from typing import Optional, Dict, List, Union
 import numpy as np
 from transformers import AutoTokenizer
 from keras_hub.models import CausalLM
-from kithara.distributed.sharding import ShardingStrategy
+from kithara.distributed.sharding import ShardingStrategy, PredefinedShardingStrategy
 from kithara.dataset.utils import initialize_tokenizer
 from kithara.model.hf_compatibility import get_model_name_from_preset_handle
 from kithara.model.model import (
@@ -75,9 +75,8 @@ class KerasHubModel(Model):
                 and "mixed_bfloat16". Mixed precision policies load weights in float32 and cast
                 activations to the specified dtype.
             sharding_strategy (Optional[ShardingStrategy]): Strategy for distributing model parameters,
-                optimizer states, and data tensors. If None, model will be replicated across all devices.
-                Defaults to None. You can use `kithara.PredefinedShardingStrategy` to easily
-                configure common sharding strategies.
+                optimizer states, and data tensors. If None, tensors will be sharded using FSDP.
+                You can use `kithara.ShardingStrategy` to configure custom sharding strategies.
 
         Returns:
             KerasHubModel: An instance of the `KerasHubModel` class.
@@ -86,15 +85,21 @@ class KerasHubModel(Model):
             ```
             model = KerasHubModel.from_preset(
                 "hf://google/gemma-2-2b",
-                lora_rank=4,
-                sharding_strategy=kithara.PredefinedShardingStrategy("fsdp", "gemma")
+                lora_rank=4
             )
             ```
         """
+
+        model_name = get_model_name_from_preset_handle(preset_handle)
+
+        if sharding_strategy is None:
+            sharding_strategy = PredefinedShardingStrategy(
+                parallelism="fsdp", model=model_name
+            )
+
         set_global_model_implementation_type(ModelImplementationType.KERASHUB)
         set_precision(precision)
         set_global_sharding_strategy(sharding_strategy)
-        model_name = get_model_name_from_preset_handle(preset_handle)
 
         model = CausalLM.from_preset(preset_handle, preprocessor=None, **kwargs)
         if lora_rank:
@@ -114,12 +119,12 @@ class KerasHubModel(Model):
         stop_token_ids=None,
         strip_prompt=False,
         **kwargs,
-    ) -> Dict[str, np.ndarray]:  
+    ) -> Dict[str, np.ndarray]:
         """Fall back to https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/models/causal_lm.py"""
-        
+
         # stop_token_ids cannot be an empty list
         stop_token_ids = stop_token_ids if stop_token_ids else None
-        
+
         tokens = self.model.generate(
             model_input,
             stop_token_ids=stop_token_ids,
@@ -131,7 +136,7 @@ class KerasHubModel(Model):
         B, _ = tokens["token_ids"].shape
         return {
             "token_ids": tokens["token_ids"][is_token][None, :].reshape(B, -1),
-            "padding_mask": tokens["padding_mask"][is_token][None, :].reshape(B, -1)
+            "padding_mask": tokens["padding_mask"][is_token][None, :].reshape(B, -1),
         }
 
     def save_in_hf_format(

--- a/kithara/model/model.py
+++ b/kithara/model/model.py
@@ -64,7 +64,7 @@ class Model(ABC, ModelValidationMixin):
     Attributes:
         sharding_strategy(kithara.ShardingStrategy): Strategy used for
             distributing model, optimizer, and data tensors.
-            E.g. `kithara.PredefinedShardingStrategy("fsdp", "gemma")`.
+            E.g. `kithara.PredefinedShardingStrategy("fsdp", "gemma2-2b")`.
         model(Keras.Model): The underlying Keras model instance.
         model_name(str, optional): Optional name of the model.
         precision(str, optional): Optional mixed-precision policy for

--- a/perf/kerashub.py
+++ b/perf/kerashub.py
@@ -56,7 +56,7 @@ def run_benchmark():
     model = KerasHubModel.from_preset(
         MODEL_HANDLE,
         precision="mixed_bfloat16",
-        sharding_strategy=PredefinedShardingStrategy(parallelism="fsdp", model="gemma"),
+        sharding_strategy=PredefinedShardingStrategy(parallelism="fsdp", model="gemma2-9b"),
     )
 
     # Create Keras optimizer

--- a/tests/callbacks/test_orbax_checkpointer.py
+++ b/tests/callbacks/test_orbax_checkpointer.py
@@ -26,7 +26,7 @@ os.environ["KERAS_BACKEND"] = "jax"
 import shutil
 import unittest
 import numpy as np
-from kithara import KerasHubModel, MaxTextModel, PredefinedShardingStrategy
+from kithara import KerasHubModel, MaxTextModel
 from kithara.callbacks.checkpointer import Checkpointer
 from kithara.utils.gcs_utils import find_cache_root_dir
 from tests.model.utils import check_arrays_match
@@ -75,8 +75,7 @@ class TestOrbaxCheckpointing(unittest.TestCase):
         # Initialize model
         model = KerasHubModel.from_preset(
             "hf://google/gemma-2-2b",
-            lora_rank=6,
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            lora_rank=6
         )
 
         # Prepare test input

--- a/tests/model/kerashub/ckpt_compatibility/test_loading_models.py
+++ b/tests/model/kerashub/ckpt_compatibility/test_loading_models.py
@@ -31,7 +31,7 @@ Usage:
 
 import unittest
 import os
-from kithara import KerasHubModel, PredefinedShardingStrategy
+from kithara import KerasHubModel
 from kithara.utils.gcs_utils import find_cache_root_dir
 from tests.model.test_prompt import TEST_PROMPT
 import tests.model.utils as utils
@@ -54,11 +54,7 @@ class TestLoadingModels(unittest.TestCase):
         """
         model = KerasHubModel.from_preset(
             preset_handle=f"hf://{model_id}",
-            precision="float32",
-            sharding_strategy=PredefinedShardingStrategy(
-                parallelism="fsdp", 
-                model="gemma"
-            ),
+            precision="float32"
         )
 
         # Run forward pass

--- a/tests/model/kerashub/ckpt_compatibility/test_saving_models.py
+++ b/tests/model/kerashub/ckpt_compatibility/test_saving_models.py
@@ -38,7 +38,7 @@ import unittest
 import shutil
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
-from kithara import KerasHubModel, PredefinedShardingStrategy
+from kithara import KerasHubModel
 from kithara.utils.gcs_utils import find_cache_root_dir
 from tests.model.test_prompt import TEST_PROMPT
 from tests.model.utils import check_arrays_match, check_predicted_tokens_match
@@ -87,11 +87,7 @@ class TestSavingModel(unittest.TestCase):
         # Create Model
         model = KerasHubModel.from_preset(
             preset_handle=f"hf://{model_id}",
-            precision="float32",
-            sharding_strategy=PredefinedShardingStrategy(
-                parallelism="fsdp", 
-                model="gemma"
-            ),
+            precision="float32"
         )
 
         # Save model

--- a/tests/model/kerashub/test_creation.py
+++ b/tests/model/kerashub/test_creation.py
@@ -19,7 +19,7 @@
 Run test on a TPU VM: python -m unittest tests/model/kerashub/test_creation.py 
 """
 import unittest
-from kithara import KerasHubModel, PredefinedShardingStrategy
+from kithara import KerasHubModel
 import time
 import unittest.result
 
@@ -35,34 +35,29 @@ class TestModelCreation(unittest.TestCase):
 
     def test_creating_gemma2_2b_model(self):
         KerasHubModel.from_preset(
-            "hf://google/gemma-2-2b",
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            "hf://google/gemma-2-2b"
         )
     def test_creating_gemma2_2b_model_with_lora(self):
         KerasHubModel.from_preset(
             "hf://google/gemma-2-2b",
-            lora_rank=6,
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            lora_rank=6
         )
         
     def test_creating_model_with_precision(self):
         model = KerasHubModel.from_preset(
             "hf://google/gemma-2-2b",
-            precision="float32",
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            precision="float32"
         )
         self.assertTrue(str(model.trainable_variables[0].value.dtype) == "float32")
 
     def test_creating_gemma2_9b_model(self):
         KerasHubModel.from_preset(
-            "hf://google/gemma-2-9b",
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            "hf://google/gemma-2-9b"
         )
     def test_creating_gemma2_2b_model_with_lora(self):
         KerasHubModel.from_preset(
             "hf://google/gemma-2-9b",
-            lora_rank=16,
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            lora_rank=16
         )
 
 if __name__ == '__main__':

--- a/tests/model/kerashub/test_inference.py
+++ b/tests/model/kerashub/test_inference.py
@@ -23,7 +23,7 @@ Note: This test suite will take around 300s in total to complete.
 import unittest
 import numpy as np
 from transformers import AutoTokenizer
-from kithara import KerasHubModel, PredefinedShardingStrategy
+from kithara import KerasHubModel
 import time
 import unittest.result
 from tests.test_utils import timeout
@@ -35,8 +35,7 @@ class TestModelGeneration(unittest.TestCase):
     def setUpClass(cls):        
         cls.model = KerasHubModel.from_preset(
             "hf://google/gemma-2-2b",
-            lora_rank=6,
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            lora_rank=6
         )
         cls.model_input = {
             "token_ids": np.array([[1, 2, 3, 0, 0]]),

--- a/tests/trainer/test_sft_e2e.py
+++ b/tests/trainer/test_sft_e2e.py
@@ -25,7 +25,6 @@ import unittest
 from kithara import (
     MaxTextModel,
     KerasHubModel,
-    PredefinedShardingStrategy,
     TextCompletionDataset,
     Dataloader,
     Checkpointer,
@@ -144,8 +143,7 @@ class TestRunningSFT(unittest.TestCase):
     def test_sft_with_kerashub_model(self):
         model = KerasHubModel.from_preset(
             preset_handle=self.MODEL_HANDLE,
-            precision=self.PRECISION,
-            sharding_strategy=PredefinedShardingStrategy("fsdp", "gemma"),
+            precision=self.PRECISION
         )
         self._run_sft(model)
 


### PR DESCRIPTION
User no longer must specify a sharding strategy when initializing a KerasHub model. 

