### PR TITLE
Support Dataset Packing

### DIFF
--- a/examples/singlehost/sft_lora_example.py
+++ b/examples/singlehost/sft_lora_example.py
@@ -49,7 +49,7 @@ config = {
     "seq_len": 4096,
     "use_lora": True,
     "lora_rank": 4,
-    "precision": "int8_from_float32",
+    "precision": "mixed_bfloat16",
     "training_steps": 100,
     "eval_steps_interval": 10,
     "log_steps_interval": 10,
@@ -72,7 +72,6 @@ def run_workload(
         f"hf://{config['model_handle']}",
         precision=config["precision"],
         lora_rank=config["lora_rank"] if config["use_lora"] else None,
-        dtype="int8"
     )
     # Create tokenizer
     tokenizer = AutoTokenizer.from_pretrained(config["model_handle"])

--- a/examples/singlehost/sft_lora_example.py
+++ b/examples/singlehost/sft_lora_example.py
@@ -39,7 +39,6 @@ from kithara import (
     KerasHubModel,
     Dataloader,
     Trainer,
-    PredefinedShardingStrategy,
     SFTDataset,
 )
 import jax
@@ -50,7 +49,7 @@ config = {
     "seq_len": 4096,
     "use_lora": True,
     "lora_rank": 4,
-    "precision": "mixed_bfloat16",
+    "precision": "int8_from_float32",
     "training_steps": 100,
     "eval_steps_interval": 10,
     "log_steps_interval": 10,
@@ -73,6 +72,7 @@ def run_workload(
         f"hf://{config['model_handle']}",
         precision=config["precision"],
         lora_rank=config["lora_rank"] if config["use_lora"] else None,
+        dtype="int8"
     )
     # Create tokenizer
     tokenizer = AutoTokenizer.from_pretrained(config["model_handle"])

--- a/kithara/__init__.py
+++ b/kithara/__init__.py
@@ -88,3 +88,6 @@ from kithara.distributed import ShardingStrategy, PredefinedShardingStrategy
 # speedup of training step up on the second run of this script.
 jax_cache_dir = os.path.join(find_cache_root_dir(), "jax_cache")
 os.environ["JAX_COMPILATION_CACHE_DIR"] = jax_cache_dir
+
+from kithara.utils.logging_utils import print_kithara_logo_and_platform_info
+print_kithara_logo_and_platform_info()

--- a/kithara/__init__.py
+++ b/kithara/__init__.py
@@ -29,6 +29,7 @@ import sys
 
 import time
 
+
 def _install_maxtext():
     try:
         importlib.metadata.version("maxtext")
@@ -74,6 +75,7 @@ def _install_maxtext():
     )
     sys.path.append(str(maxtext_dir))
 
+
 _install_maxtext()
 
 from kithara.dataset import Dataloader, SFTDataset, TextCompletionDataset
@@ -90,7 +92,8 @@ jax_cache_dir = os.path.join(find_cache_root_dir(), "jax_cache")
 os.environ["JAX_COMPILATION_CACHE_DIR"] = jax_cache_dir
 
 from kithara.utils.logging_utils import print_kithara_logo_and_platform_info
+
 try:
     print_kithara_logo_and_platform_info()
-except Exception as e: 
+except Exception as e:
     pass

--- a/kithara/__init__.py
+++ b/kithara/__init__.py
@@ -90,4 +90,7 @@ jax_cache_dir = os.path.join(find_cache_root_dir(), "jax_cache")
 os.environ["JAX_COMPILATION_CACHE_DIR"] = jax_cache_dir
 
 from kithara.utils.logging_utils import print_kithara_logo_and_platform_info
-print_kithara_logo_and_platform_info()
+try:
+    print_kithara_logo_and_platform_info()
+except Exception as e: 
+    pass

--- a/kithara/dataset/packed_dataset.py
+++ b/kithara/dataset/packed_dataset.py
@@ -1,6 +1,5 @@
 import numpy as np
 from typing import Dict, List, Union, Optional
-from kithara.dataset.text_completion import TextCompletionDataset
 from kithara.dataset.dataset import Dataset
 import ray
 
@@ -69,7 +68,7 @@ class PackedDataset(Dataset):
 
     def __init__(
         self,
-        source_dataset: TextCompletionDataset,
+        source_dataset: "TextCompletionDataset",
         pad_value: int = 0,
     ):
         super().__init__(source_dataset.source)

--- a/kithara/dataset/packed_dataset.py
+++ b/kithara/dataset/packed_dataset.py
@@ -36,14 +36,11 @@ class PackedDataset(Dataset):
 
     def process_sample(self, input: Dict[str, any]) -> Dict[str, np.ndarray]:
         """Pack multiple sequences into a single fixed-length sequence with segmentation and position information."""
-        print("process_sample in PackedDataset")
         input_tokens = input["x"]["tokens"]
-        print("input_tokens", input_tokens.shape)
         input_segment_ids = input["x"]["segment_ids"]
         input_positions = input["x"]["positions"]
         targets = input["y"]
         target_length = targets.shape[-1]
-        print("target_length", target_length)
 
         if self._buffer is None or self._buffer_full:
             self._buffer = input
@@ -52,7 +49,6 @@ class PackedDataset(Dataset):
             self._buffer_full = False
 
         sequence_length = np.sum(input_segment_ids)
-        print("sequence_length", sequence_length)
         # If we can't fit this sequence, break
         if self._current_position + sequence_length > target_length:
             self._buffer_full = True
@@ -84,3 +80,11 @@ class PackedDataset(Dataset):
                 yield processed
 
         # Drop the last sample
+
+    def __getattr__(self, name):
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            # If not found, delegate to source_dataset
+            ds = object.__getattribute__(self, "source_dataset")
+            return getattr(ds, name, None)

--- a/kithara/dataset/packed_dataset.py
+++ b/kithara/dataset/packed_dataset.py
@@ -1,0 +1,86 @@
+import numpy as np
+from typing import Dict, List, Union, Optional
+from kithara.dataset.dataset import Dataset
+import ray
+
+
+class PackedDataset(Dataset):
+    """A dataset class that packs multiple sequences together for more efficient processing.
+
+    This implementation packs multiple sequences into fixed-length segments, similar to how
+    T5 and other transformer implementations handle packing. For each key in the input,
+    it creates two additional fields: {key}_segmentation and {key}_position to track
+    the original sequences.
+
+    Args:
+        source_dataset (Dataset): The source Kithara dataset to pack
+        batch_size (int): Number of sequences to batch together before packing
+        pad_value (int): Value to use for padding (default: -1)
+    """
+
+    def __init__(
+        self,
+        source_dataset: Dataset,
+        pad_value: int = 0,
+    ):
+        super().__init__(source_dataset.source)
+
+        self.source_dataset = source_dataset
+        self.pad_value = pad_value
+
+        # Initialize buffers for packing
+        self._buffer = None
+        self._buffer_full = False
+        self._segment_id = 1
+        self._current_position = 0
+
+    def process_sample(self, input: Dict[str, any]) -> Dict[str, np.ndarray]:
+        """Pack multiple sequences into a single fixed-length sequence with segmentation and position information."""
+        print("process_sample in PackedDataset")
+        input_tokens = input["x"]["tokens"]
+        print("input_tokens", input_tokens.shape)
+        input_segment_ids = input["x"]["segment_ids"]
+        input_positions = input["x"]["positions"]
+        targets = input["y"]
+        target_length = targets.shape[-1]
+        print("target_length", target_length)
+
+        if self._buffer is None or self._buffer_full:
+            self._buffer = input
+            self._segment_id = 1
+            self._current_position = 0
+            self._buffer_full = False
+
+        sequence_length = np.sum(input_segment_ids)
+        print("sequence_length", sequence_length)
+        # If we can't fit this sequence, break
+        if self._current_position + sequence_length > target_length:
+            self._buffer_full = True
+            return self._buffer
+
+        # Add the sequence
+        self._buffer["x"]["tokens"][
+            :, self._current_position : self._current_position + sequence_length
+        ] = input_tokens[:, :sequence_length]
+        self._buffer["x"]["segment_ids"][
+            :, self._current_position : self._current_position + sequence_length
+        ] = (input_segment_ids[:, :sequence_length] * self._segment_id)
+        self._buffer["x"]["positions"][
+            :, self._current_position : self._current_position + sequence_length
+        ] = input_positions[:, :sequence_length]
+        self._buffer["y"][
+            :, self._current_position : self._current_position + sequence_length
+        ] = targets[:, :sequence_length]
+        self._segment_id += 1
+        self._current_position += sequence_length
+
+        return None
+
+    def __iter__(self):
+        """Iterate over packed samples."""
+        for sample in self.source_dataset:
+            processed = self.process_sample(sample)
+            if processed is not None:
+                yield processed
+
+        # Drop the last sample

--- a/kithara/dataset/text_completion.py
+++ b/kithara/dataset/text_completion.py
@@ -35,10 +35,14 @@ class TextCompletionDataset(Dataset):
         tokenizer_handle: Handle/name of the tokenizer to load if not provided.
         column_mapping (Optional[Dict]): Mapping of source column name to expected
             column name ("text")
-        model_type (Optional[ModelImplementationType]): Type of model implementation to use.
-            Please specify model_type or set MODEL_IMPLEMENTATION in global state. Global
-            state is automatically set upon model initialization. Supported types:
-            ModelImplementationType.KERASHUB, ModelImplementationType.MAXTEXT
+        model_type (ModelImplementationType | "auto"): Type of model implementation to use.
+            MaxText and KerasHub models expect input formats, the dataset needs to know 
+            which model it is feeding data to. This field can be set to "auto" or a specific
+            model type. Supported mode_type: ModelImplementationType.KERASHUB, 
+            ModelImplementationType.MAXTEXT. When set to "auto", model_type will be inferred 
+            from the `MODEL_IMPLEMENTATION` global state. `MODEL_IMPLEMENTATION` will be
+            automatically set upon model initialization. You should only need to manually
+            specify this argument when you are creating a dataset without creating a model.
         max_seq_len (int): Maximum sequence length for tokenization (default: 1024).
         custom_formatting_fn（callable): A custom formatting function to apply to the raw
             sample before any other transformation steps.
@@ -50,7 +54,7 @@ class TextCompletionDataset(Dataset):
         tokenizer: AutoTokenizer = None,
         tokenizer_handle: str = None,
         column_mapping: Dict[str, str] = None,
-        model_type: "ModelImplementationType" = "KerasHub",
+        model_type: "ModelImplementationType" = "auto",
         max_seq_len: int = 1024,
         custom_formatting_fn: Optional[callable] = None,
         packing=False,
@@ -61,18 +65,38 @@ class TextCompletionDataset(Dataset):
             tokenizer_handle is not None
         ), "Either a HF Tokenizer or a HF tokenizer handle must be provided"
 
-        self.source = source
         self.max_seq_len = max_seq_len
         self.tokenizer = (
             initialize_tokenizer(tokenizer_handle) if tokenizer is None else tokenizer
         )
         self.tokenizer.pad_token = "<pad>"
         self.column_mapping = {"text": "text"}
-        self.model_type = model_type
+        self._model_type = model_type
         self.custom_formatting_fn = custom_formatting_fn
         self.packing = packing
         if column_mapping:
             self.column_mapping = {**self.column_mapping, **column_mapping}
+
+    @property
+    def model_type(self):
+        # Avoid circular import
+        from kithara.model import ModelImplementationType
+
+        if self._model_type=="auto":
+            model_type= global_state.get_global_attribute(
+            "MODEL_IMPLEMENTATION", None
+        )
+        else:
+            model_type = self._model_type
+            
+        if model_type not in ModelImplementationType.list_supported_types():
+            raise ValueError(
+                "Did you forget to specify model_type during Dataset creation? Please specify model_type or set MODEL_IMPLEMENTATION "
+                "in global state. Supported types: `KerasHub`, `MaxText`. You don't need to specify model type if you have already created"
+                " a model. "
+            )
+
+        return model_type
 
     def task_transform(self, sample):
         """Transform the raw sample with standardized key."""
@@ -115,18 +139,6 @@ class TextCompletionDataset(Dataset):
         # Avoid circular import
         from kithara.model import ModelImplementationType
 
-        # global attribute takes precedence
-        model_type = global_state.get_global_attribute(
-            "MODEL_IMPLEMENTATION", self.model_type
-        )
-
-        if not model_type:
-            raise ValueError(
-                "Did you forget to specify model_type during Dataset creation? Please specify model_type or set MODEL_IMPLEMENTATION "
-                "in global state. Supported types: `KerasHub`, `MaxText`. You don't need to specify model type if you have already created"
-                " a model. "
-            )
-
         input_formats = {
             ModelImplementationType.MAXTEXT: lambda: {
                 "x": {
@@ -142,10 +154,10 @@ class TextCompletionDataset(Dataset):
             },
         }
 
-        if model_type not in input_formats:
-            raise ValueError(f"Unsupported model type: {model_type}")
+        if self.model_type not in input_formats:
+            raise ValueError(f"Unsupported model type: {self.model_type}")
 
-        return input_formats[model_type]()
+        return input_formats[self.model_type]()
 
     def process_sample(self, sample: int) -> Dict[str, np.ndarray]:
         """Overrides the base class implementation. This function
@@ -180,9 +192,8 @@ class TextCompletionDataset(Dataset):
         """
         from kithara.model import ModelImplementationType
 
-
         assert (
             self.model_type == ModelImplementationType.MAXTEXT
-        ), "Packing only works for MaxText models."
+        ), f"Packing only works for MaxText models, and doesn not works for {self.model_type}"
 
         return PackedDataset(self, pad_value=self.tokenizer.pad_token_id)

--- a/kithara/dataset/text_completion.py
+++ b/kithara/dataset/text_completion.py
@@ -164,7 +164,7 @@ class TextCompletionDataset(Dataset):
         )
         return sample
 
-    def to_packed_dataset(self) -> "PackedDataset":
+    def to_packed_dataset(self) -> PackedDataset:
         """Converts the current dataset to a PackedDataset for more efficient processing.
 
         The PackedDataset combines multiple sequences into single fixed-length sequences
@@ -179,6 +179,7 @@ class TextCompletionDataset(Dataset):
                 together, using the tokenizer's pad token ID for padding.
         """
         from kithara.model import ModelImplementationType
+
 
         assert (
             self.model_type == ModelImplementationType.MAXTEXT

--- a/kithara/dataset/text_completion.py
+++ b/kithara/dataset/text_completion.py
@@ -15,6 +15,7 @@
  """
 
 from kithara.dataset.dataset import Dataset
+from kithara.dataset.packed_dataset import PackedDataset
 from kithara.dataset.utils import initialize_tokenizer, HFtokenize
 import ray
 from keras.src.backend.common import global_state
@@ -52,6 +53,7 @@ class TextCompletionDataset(Dataset):
         model_type: "ModelImplementationType" = "KerasHub",
         max_seq_len: int = 1024,
         custom_formatting_fn: Optional[callable] = None,
+        packing = False
     ):
         super().__init__(source)
 
@@ -68,6 +70,7 @@ class TextCompletionDataset(Dataset):
         self.column_mapping = {"text": "text"}
         self.model_type = model_type
         self.custom_formatting_fn = custom_formatting_fn
+        self.packing = packing
         if column_mapping:
             self.column_mapping = {**self.column_mapping, **column_mapping}
 
@@ -161,5 +164,5 @@ class TextCompletionDataset(Dataset):
         )
         return sample
 
-    def to_packed_dataset(self) -> "PackedDataset":
-        raise NotImplementedError("Packing is not currently supported")
+    def to_packed_dataset(self) -> "PackedDataset": 
+        return PackedDataset(self, pad_value=self.tokenizer.pad_token_id)

--- a/kithara/dataset/text_completion.py
+++ b/kithara/dataset/text_completion.py
@@ -40,8 +40,8 @@ class TextCompletionDataset(Dataset):
             state is automatically set upon model initialization. Supported types:
             ModelImplementationType.KERASHUB, ModelImplementationType.MAXTEXT
         max_seq_len (int): Maximum sequence length for tokenization (default: 1024).
-        custom_formatting_fn（callable): A custom formatting function to apply to the raw 
-            sample before any other transformation steps. 
+        custom_formatting_fn（callable): A custom formatting function to apply to the raw
+            sample before any other transformation steps.
     """
 
     def __init__(
@@ -53,7 +53,7 @@ class TextCompletionDataset(Dataset):
         model_type: "ModelImplementationType" = "KerasHub",
         max_seq_len: int = 1024,
         custom_formatting_fn: Optional[callable] = None,
-        packing = False
+        packing=False,
     ):
         super().__init__(source)
 
@@ -115,7 +115,7 @@ class TextCompletionDataset(Dataset):
         # Avoid circular import
         from kithara.model import ModelImplementationType
 
-        # global attribute takes precedence 
+        # global attribute takes precedence
         model_type = global_state.get_global_attribute(
             "MODEL_IMPLEMENTATION", self.model_type
         )
@@ -164,5 +164,24 @@ class TextCompletionDataset(Dataset):
         )
         return sample
 
-    def to_packed_dataset(self) -> "PackedDataset": 
+    def to_packed_dataset(self) -> "PackedDataset":
+        """Converts the current dataset to a PackedDataset for more efficient processing.
+
+        The PackedDataset combines multiple sequences into single fixed-length sequences
+        to maximize computational efficiency during training. This is particularly useful
+        for handling variable-length sequences by packing them together with proper
+        segmentation and position information.
+
+        Packing currently only works for MaxText models.
+
+        Returns:
+            PackedDataset: A new dataset instance that packs sequences from this dataset
+                together, using the tokenizer's pad token ID for padding.
+        """
+        from kithara.model import ModelImplementationType
+
+        assert (
+            self.model_type == ModelImplementationType.MAXTEXT
+        ), "Packing only works for MaxText models."
+
         return PackedDataset(self, pad_value=self.tokenizer.pad_token_id)

--- a/kithara/distributed/sharding/models/gemma.py
+++ b/kithara/distributed/sharding/models/gemma.py
@@ -17,15 +17,15 @@
 from kithara.distributed.sharding._mesh import Axis
 
 GEMMA_FSDP = {
-    ".*token_embedding.embeddings.*": (None, Axis.FSDP),
-    ".*decoder_block.*attention.*(query|key|value).kernel.*": (
+    ".*token_embedding.embeddings$": (None, Axis.FSDP),
+    ".*decoder_block.*attention.*(query|key|value).kernel$": (
         None,
         Axis.FSDP,
     ),
-    ".*decoder_block.*attention_output.kernel.*": (None, None, Axis.FSDP),
-    ".*decoder_block.*ffw_gating.kernel.*": (None, Axis.FSDP),
-    ".*decoder_block.*ffw_gating_2.kernel.*": (None, Axis.FSDP),
-    ".*decoder_block.*ffw_linear.kernel.*": (Axis.FSDP, None),
+    ".*decoder_block.*attention_output.kernel$": (None, None, Axis.FSDP),
+    ".*decoder_block.*ffw_gating.kernel$": (None, Axis.FSDP),
+    ".*decoder_block.*ffw_gating_2.kernel$": (None, Axis.FSDP),
+    ".*decoder_block.*ffw_linear.kernel$": (Axis.FSDP, None),
     # Lora layers
     ".*decoder_block.*attention.*(query|key|value).lora_kernel.*": (
         None,

--- a/kithara/distributed/sharding/models/gemma.py
+++ b/kithara/distributed/sharding/models/gemma.py
@@ -17,15 +17,15 @@
 from kithara.distributed.sharding._mesh import Axis
 
 GEMMA_FSDP = {
-    ".*token_embedding.embeddings$": (None, Axis.FSDP),
-    ".*decoder_block.*attention.*(query|key|value).kernel$": (
+    ".*token_embedding.embeddings.*": (None, Axis.FSDP),
+    ".*decoder_block.*attention.*(query|key|value).kernel.*": (
         None,
         Axis.FSDP,
     ),
-    ".*decoder_block.*attention_output.kernel$": (None, None, Axis.FSDP),
-    ".*decoder_block.*ffw_gating.kernel$": (None, Axis.FSDP),
-    ".*decoder_block.*ffw_gating_2.kernel$": (None, Axis.FSDP),
-    ".*decoder_block.*ffw_linear.kernel$": (Axis.FSDP, None),
+    ".*decoder_block.*attention_output.kernel.*": (None, None, Axis.FSDP),
+    ".*decoder_block.*ffw_gating.kernel.*": (None, Axis.FSDP),
+    ".*decoder_block.*ffw_gating_2.kernel.*": (None, Axis.FSDP),
+    ".*decoder_block.*ffw_linear.kernel.*": (Axis.FSDP, None),
     # Lora layers
     ".*decoder_block.*attention.*(query|key|value).lora_kernel.*": (
         None,

--- a/kithara/model/model.py
+++ b/kithara/model/model.py
@@ -351,7 +351,6 @@ class Model(ABC, ModelValidationMixin):
                 )
 
         def next_token(current_inputs):
-            start_time = time.time()
             current_inputs = jax.device_put(
                 current_inputs, self.sharding_strategy.data_sharding
             )
@@ -377,7 +376,7 @@ class Model(ABC, ModelValidationMixin):
         # Track which sequences have reached EOS
         reached_eos = [False for _ in range(batch_size)]
 
-        for i in range(generate_steps):
+        for s in range(generate_steps):
             current_inputs = {
                 **inputs,
                 tokens_key: tokens,
@@ -404,6 +403,7 @@ class Model(ABC, ModelValidationMixin):
                 if token in stop_token_ids:
                     reached_eos[i] = True
             if np.all(reached_eos):
+                generate_steps = s+1
                 break
 
         token_ids = tokens[:batch_size, :num_tokens]

--- a/kithara/trainer/trainer.py
+++ b/kithara/trainer/trainer.py
@@ -293,7 +293,6 @@ class Trainer:
             # the per-token loss (i.e. average of the loss from #non-padding tokens in batch).
             # The *epoch loss* is simply the average of the step losses. It is not the exact
             # per-token loss across the epoch, but rather a proxy.
-            # print("train batches_seen_in_epoch", batches_seen_in_epoch)
             epoch_loss = epoch_loss / batches_seen_in_epoch
             self.callbacks.on_epoch_end(self.epoch_count, {"epoch_loss": epoch_loss})
             print(f"Train epoch {self.epoch_count} loss : {epoch_loss}")

--- a/kithara/trainer/trainer.py
+++ b/kithara/trainer/trainer.py
@@ -145,6 +145,7 @@ class Trainer:
         """
         return keras.losses.SparseCategoricalCrossentropy(
             from_logits=True,
+            reduction="mean",  # per token loss
             ignore_class=self.train_dataloader.dataset.tokenizer.pad_token_id,
         )
 
@@ -238,7 +239,7 @@ class Trainer:
             self.callbacks.on_epoch_begin(self.epoch_count)
 
             epoch_loss = 0
-            train_set_size = 0
+            batches_seen_in_epoch = 0
 
             # Process each batch in the epoch
             for batch_input in self.train_dataloader:
@@ -256,8 +257,8 @@ class Trainer:
                 # Execute training step
                 loss, state = self.train_step(state, batch_input)
                 epoch_loss += loss
-                train_set_size += self.global_batch_size
-
+                batches_seen_in_epoch += 1
+                
                 # Log progress
                 if (
                     self.step_count == 1
@@ -288,7 +289,12 @@ class Trainer:
                     self.evaluate(state)
 
             # Compute epoch statistics
-            epoch_loss = epoch_loss / train_set_size
+            # If no custom loss_fn is supplied, the default *step loss* calculates
+            # the per-token loss (i.e. average of the loss from #non-padding tokens in batch).
+            # The *epoch loss* is simply the average of the step losses. It is not the exact
+            # per-token loss across the epoch, but rather a proxy.
+            # print("train batches_seen_in_epoch", batches_seen_in_epoch)
+            epoch_loss = epoch_loss / batches_seen_in_epoch
             self.callbacks.on_epoch_end(self.epoch_count, {"epoch_loss": epoch_loss})
             print(f"Train epoch {self.epoch_count} loss : {epoch_loss}")
 
@@ -363,11 +369,11 @@ class Trainer:
         # Initialize evaluation
         self.callbacks.on_test_begin()
         eval_loss = 0
-        eval_set_size = 0
+        eval_batches_seen = 0
 
         # Process each batch in evaluation dataset
         for step_i, batch_input in enumerate(self.eval_dataloader):
-            if eval_set_size + self.global_batch_size > self.max_eval_samples:
+            if (eval_batches_seen + 1) * self.global_batch_size > self.max_eval_samples:
                 break
 
             start_time = time.time()
@@ -380,7 +386,7 @@ class Trainer:
 
             # Accumulate metrics
             eval_loss += loss
-            eval_set_size += self.global_batch_size
+            eval_batches_seen += 1
 
             # Logging
             if (step_i + 1) % self.log_steps_interval == 0:
@@ -389,7 +395,7 @@ class Trainer:
                 print(f"Eval step {step_i+1} loss {loss}")
 
         # Compute final metrics and report results
-        eval_loss = eval_loss / eval_set_size
+        eval_loss = eval_loss / eval_batches_seen
         self.callbacks.on_test_end({"loss": eval_loss})
         print(f"Eval loss after {self.step_count} training steps: ", eval_loss)
         return eval_loss

--- a/kithara/utils/logging_utils.py
+++ b/kithara/utils/logging_utils.py
@@ -1,7 +1,6 @@
-
-
 import jax
 import platform
+
 
 def get_device_stats():
     device_count = jax.device_count()
@@ -16,16 +15,18 @@ def get_device_stats():
         "total_memory_gb": round(total_memory, 2),
     }
 
+
 def print_kithara_logo_and_platform_info():
     platform_system = platform.system()
     tpu_stats = get_device_stats()
-    statistics = \
-        f"       '==='\n"\
-        f"        |||\n"\
-        f"     '- ||| -'\n"\
-        f"    /  |||||  \\   Kithara. Platform: {platform_system}. JAX: {jax.__version__}\n"\
-        f"   |   (|||)   |  Hardware: {tpu_stats['device_kind']}. Device count: {tpu_stats['device_count']}.\n"\
-        f"   |   |◕‿◕|   |  HBM Per Device: {tpu_stats['memory_per_device_gb']} GB. Total HBM Memory: {tpu_stats['total_memory_gb']} GB\n"\
-        f"    \\  |||||  /   Free Apache license: http://github.com/ai-hypercomputer/kithara\n"\
+    statistics = (
+        f"       '==='\n"
+        f"        |||\n"
+        f"     '- ||| -'\n"
+        f"    /  |||||  \\   Kithara. Platform: {platform_system}. JAX: {jax.__version__}\n"
+        f"   |   (|||)   |  Hardware: {tpu_stats['device_kind']}. Device count: {tpu_stats['device_count']}.\n"
+        f"   |   |◕‿◕|   |  HBM Per Device: {tpu_stats['memory_per_device_gb']} GB. Total HBM Memory: {tpu_stats['total_memory_gb']} GB\n"
+        f"    \\  |||||  /   Free Apache license: http://github.com/ai-hypercomputer/kithara\n"
         f"     --|===|--"
+    )
     print(statistics)

--- a/kithara/utils/logging_utils.py
+++ b/kithara/utils/logging_utils.py
@@ -1,0 +1,31 @@
+
+
+import jax
+import platform
+
+def get_device_stats():
+    device_count = jax.device_count()
+    device_kind = jax.devices()[0].device_kind
+    memory_info = jax.devices()[0].memory_stats()
+    memory_per_device = memory_info["bytes_limit"] / (1024**3)  # Convert to GB
+    total_memory = memory_per_device * device_count
+    return {
+        "device_count": device_count,
+        "device_kind": device_kind,
+        "memory_per_device_gb": round(memory_per_device, 2),
+        "total_memory_gb": round(total_memory, 2),
+    }
+
+def print_kithara_logo_and_platform_info():
+    platform_system = platform.system()
+    tpu_stats = get_device_stats()
+    statistics = \
+        f"       '==='\n"\
+        f"        |||\n"\
+        f"     '- ||| -'\n"\
+        f"    /  |||||  \\   Kithara. Platform: {platform_system}. JAX: {jax.__version__}\n"\
+        f"   |   (|||)   |  Hardware: {tpu_stats['device_kind']}. Device count: {tpu_stats['device_count']}.\n"\
+        f"   |   |◕‿◕|   |  HBM Per Device: {tpu_stats['memory_per_device_gb']} GB. Total HBM Memory: {tpu_stats['total_memory_gb']} GB\n"\
+        f"    \\  |||||  /   Free Apache license: http://github.com/ai-hypercomputer/kithara\n"\
+        f"     --|===|--"
+    print(statistics)

--- a/tests/dataset/test_dataset_packing.py
+++ b/tests/dataset/test_dataset_packing.py
@@ -70,6 +70,18 @@ class TestDatasetCreation(unittest.TestCase):
             self.assertEqual(np.max(element["x"]["positions"]), 2)
             self.assertEqual(np.min(element["x"]["positions"]), 0)
 
+    def test_creating_small_dataset(self):
+        dataset_items = [
+            {"text": f"T"} for i in range(50)
+        ]
+        ray_dataset = ray.data.from_items(dataset_items)
+        dataset = TextCompletionDataset(
+            ray_dataset, tokenizer_handle="hf://google/gemma-2-2b", model_type="MaxText", max_seq_len=300
+        ).to_packed_dataset()
+
+        self.assertEqual(len(dataset), 50)
+        self.assertIsNotNone(next(iter(dataset)))
+
     def test_creating_sft_packing_dataset(self):
         dataset_items = [
             {"prompt": "T", "answer": "0"} for i in range(1000)

--- a/tests/dataset/test_dataset_packing.py
+++ b/tests/dataset/test_dataset_packing.py
@@ -1,0 +1,93 @@
+"""
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+"""Unit tests for creating Kithara Datasets
+
+Run test on a TPU VM: python -m unittest tests/dataset/test_dataset_packing.py 
+"""
+
+import unittest
+from kithara import SFTDataset, TextCompletionDataset
+import time
+import unittest.result
+import tests.dataset.utils as dataset_utils
+import numpy as np
+import os
+import ray
+
+
+class TestDatasetCreation(unittest.TestCase):
+
+    def setUp(self):
+        print(f"\nStarting test: {self._testMethodName}")
+        self.start_time = time.time()
+
+    def tearDown(self):
+        duration = time.time() - self.start_time
+        print(f"Completed test: {self._testMethodName} in {duration:.2f} seconds\n")
+
+    def _check_dataset_item_format(self, element):
+        self.assertTrue(isinstance(element, dict))
+        self.assertTrue("x" in element)
+        self.assertTrue("y" in element)
+        self.assertTrue("tokens" in element["x"])
+        self.assertTrue("segment_ids" in element["x"])
+        self.assertTrue("positions" in element["x"])
+        self.assertTrue(isinstance(element["x"]["tokens"], np.ndarray))
+        self.assertTrue(isinstance(element["x"]["segment_ids"], np.ndarray))
+        self.assertTrue(isinstance(element["x"]["positions"], np.ndarray))
+        self.assertTrue(isinstance(element["y"], np.ndarray))
+
+    def test_creating_text_completion_packing_dataset(self):
+        dataset_items = [
+            {"text": f"T"} for i in range(1000)
+        ]
+        ray_dataset = ray.data.from_items(dataset_items)
+        dataset = TextCompletionDataset(
+            ray_dataset, tokenizer_handle="hf://google/gemma-2-2b", model_type="MaxText", max_seq_len=300
+        ).to_packed_dataset()
+
+        for element in dataset:
+            self._check_dataset_item_format(element)
+            # Segment id should look like 1,1,1,2,2,2,3,3,3,...100,100,100
+            self.assertEqual(np.max(element["x"]["segment_ids"]), 100)
+            self.assertEqual(np.min(element["x"]["segment_ids"]), 1)
+
+            # Positions should look like 0, 1,2,0, 1,2,,...., 0, 1,2
+            self.assertEqual(np.max(element["x"]["positions"]), 2)
+            self.assertEqual(np.min(element["x"]["positions"]), 0)
+
+    def test_creating_sft_packing_dataset(self):
+        dataset_items = [
+            {"prompt": "T", "answer": "0"} for i in range(1000)
+        ]
+        ray_dataset = ray.data.from_items(dataset_items)
+        dataset = SFTDataset(
+            ray_dataset, tokenizer_handle="hf://google/gemma-2-2b", model_type="MaxText", max_seq_len=400
+        ).to_packed_dataset()
+
+        for element in dataset:
+            self._check_dataset_item_format(element)
+            # Segment id should look like 1,1,1,1,2,2,2,2,3,3,3,...100,100,100, 100
+            self.assertEqual(np.max(element["x"]["segment_ids"]), 100)
+            self.assertEqual(np.min(element["x"]["segment_ids"]), 1)
+            
+            # Positions should look like 0, 1,2,3,4, 0, 1,2,3,4,...., 0, 1,2,3,4
+            self.assertEqual(np.max(element["x"]["positions"]), 3)
+            self.assertEqual(np.min(element["x"]["positions"]), 0)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/dataset/utils.py
+++ b/tests/dataset/utils.py
@@ -17,9 +17,9 @@
 import ray 
 from datasets import load_dataset
 
-def create_dict_ray_dataset():    
+def create_dict_ray_dataset(n=1000):    
     dataset_items = [
-        {"text": f"{i} What is your name? My name is Kithara."} for i in range(1000)
+        {"text": f"{i} What is your name? My name is Kithara."} for i in range(n)
     ]
     return ray.data.from_items(dataset_items)
 

--- a/tests/trainer/test_sft_e2e.py
+++ b/tests/trainer/test_sft_e2e.py
@@ -19,6 +19,7 @@
 Run test on a TPU VM: python -m unittest tests/trainer/test_sft_e2e.py 
 """
 import os
+
 os.environ["KERAS_BACKEND"] = "jax"
 
 import unittest
@@ -28,14 +29,14 @@ from kithara import (
     TextCompletionDataset,
     Dataloader,
     Checkpointer,
-    Trainer
+    Trainer,
 )
 import unittest.result
 
 import ray
 from kithara.utils.gcs_utils import find_cache_root_dir
 import shutil
-import keras 
+import keras
 
 
 class TestRunningSFT(unittest.TestCase):
@@ -60,12 +61,12 @@ class TestRunningSFT(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.TMP_DIR, ignore_errors=True)
 
-    def _create_datasets(self):
+    def _create_datasets(self, packing=False):
         dataset_items = [
-            {"text": f"{i} What is your name? My name is Mary."} for i in range(1000)
+            {"text": f"{i} What is your name? My name is Mary."} for i in range(2000)
         ]
         dataset = ray.data.from_items(dataset_items)
-        train_source, eval_source = dataset.train_test_split(test_size=500)
+        train_source, eval_source = dataset.train_test_split(test_size=1000)
 
         train_dataset = TextCompletionDataset(
             train_source,
@@ -77,12 +78,14 @@ class TestRunningSFT(unittest.TestCase):
             tokenizer_handle=self.TOKENIZER_HANDLE,
             max_seq_len=self.SEQ_LEN,
         )
+        if packing:
+            train_dataset = train_dataset.to_packed_dataset()
+            eval_dataset = eval_dataset.to_packed_dataset()
+
         return train_dataset, eval_dataset
 
-    def _run_sft(self, model):
+    def _run_sft(self, model, train_dataset, eval_dataset, save_model=True):
 
-        train_dataset, eval_dataset = self._create_datasets()
-        
         train_dataloader = Dataloader(
             train_dataset,
             per_device_batch_size=self.PER_DEVICE_BATCH_SIZE,
@@ -119,17 +122,19 @@ class TestRunningSFT(unittest.TestCase):
             log_steps_interval=self.LOG_STEPS_INTERVAL,
             max_eval_samples=self.MAX_EVAL_SAMPLES,
             checkpointer=checkpointer,
-            tensorboard_dir=os.path.join(self.TMP_DIR, "tensorboard")
+            tensorboard_dir=os.path.join(self.TMP_DIR, "tensorboard"),
         )
 
         # Start training
         trainer.train()
 
         # Save model in HuggingFace format
-        model.save_in_hf_format(os.path.join(self.TMP_DIR, "hf"))
+        if save_model:
+            model.save_in_hf_format(os.path.join(self.TMP_DIR, "hf"))
 
-    @unittest.skipIf(int(os.getenv('RUN_LIGHT_TESTS_ONLY', 0)) == 1, "Heavy Test")
+    @unittest.skipIf(int(os.getenv("RUN_LIGHT_TESTS_ONLY", 0)) == 1, "Heavy Test")
     def test_sft_with_maxtext_model(self):
+        train_dataset, eval_dataset = self._create_datasets()
         model = MaxTextModel.from_preset(
             preset_handle=self.MODEL_HANDLE,
             seq_len=self.SEQ_LEN,
@@ -137,15 +142,27 @@ class TestRunningSFT(unittest.TestCase):
             precision=self.PRECISION,
             scan_layers=True,
         )
-        self._run_sft(model)
+        self._run_sft(model, train_dataset, eval_dataset)
 
-    @unittest.skipIf(int(os.getenv('RUN_LIGHT_TESTS_ONLY', 0)) == 1, "Heavy Test")
+    @unittest.skipIf(int(os.getenv("RUN_LIGHT_TESTS_ONLY", 0)) == 1, "Heavy Test")
     def test_sft_with_kerashub_model(self):
+        train_dataset, eval_dataset = self._create_datasets()
         model = KerasHubModel.from_preset(
-            preset_handle=self.MODEL_HANDLE,
-            precision=self.PRECISION
+            preset_handle=self.MODEL_HANDLE, precision=self.PRECISION
         )
-        self._run_sft(model)
+        self._run_sft(model, train_dataset, eval_dataset)
+
+    @unittest.skipIf(int(os.getenv("RUN_LIGHT_TESTS_ONLY", 0)) == 1, "Heavy Test")
+    def test_sft_with_packing(self):
+        packed_train_dataset, packed_eval_dataset = self._create_datasets(packing=True)
+        model = MaxTextModel.from_random(
+            "default",
+            seq_len=self.SEQ_LEN,
+            per_device_batch_size=self.PER_DEVICE_BATCH_SIZE,
+            precision=self.PRECISION,
+            scan_layers=True,
+        )
+        self._run_sft(model, packed_train_dataset, packed_eval_dataset, save_model=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Supporting running Continued Pretraining and SFT with Dataset Packing. Dataset Packing is a technique that allows for training multiple shorter sequences in the same sample. Please see b/396676086 for performance gain, as well as correctness check. 

We changed the per-sample loss to a per-token loss to accommodate for packing. 